### PR TITLE
chore: update all URLs from play-qris.vercel.app to qris.zeranel.dev

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -4,7 +4,7 @@ import { Inter } from "next/font/google";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata = {
-  metadataBase: new URL("https://play-qris.vercel.app"),
+  metadataBase: new URL("https://qris.zeranel.dev"),
   title: {
     default: "PlayQRIS — Read & Edit QRIS Payment Data",
     template: "%s | PlayQRIS",
@@ -42,7 +42,7 @@ export const metadata = {
     type: "website",
     locale: "en_US",
     alternateLocale: ["id_ID"],
-    url: "https://play-qris.vercel.app",
+    url: "https://qris.zeranel.dev",
     siteName: "PlayQRIS",
     title: "PlayQRIS — Read & Edit QRIS Payment Data",
     description:
@@ -77,10 +77,10 @@ export const metadata = {
     },
   },
   alternates: {
-    canonical: "https://play-qris.vercel.app",
+    canonical: "https://qris.zeranel.dev",
     languages: {
-      en: "https://play-qris.vercel.app",
-      id: "https://play-qris.vercel.app/id",
+      en: "https://qris.zeranel.dev",
+      id: "https://qris.zeranel.dev/id",
     },
   },
   icons: {
@@ -94,7 +94,7 @@ const structuredData = {
   "@context": "https://schema.org",
   "@type": "WebApplication",
   name: "PlayQRIS",
-  url: "https://play-qris.vercel.app",
+  url: "https://qris.zeranel.dev",
   description:
     "Read, validate, and edit QRIS (Indonesian QR Code Standard) payment data.",
   applicationCategory: "FinanceApplication",

--- a/app/robots.js
+++ b/app/robots.js
@@ -8,7 +8,7 @@ export default function robots() {
         disallow: ["/api/*", "/_next/*"],
       },
     ],
-    sitemap: "https://play-qris.vercel.app/sitemap.xml",
-    host: "https://play-qris.vercel.app",
+    sitemap: "https://qris.zeranel.dev/sitemap.xml",
+    host: "https://qris.zeranel.dev",
   };
 }

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -2,7 +2,7 @@
 export default function sitemap() {
   return [
     {
-      url: "https://play-qris.vercel.app",
+      url: "https://qris.zeranel.dev",
       lastModified: new Date(),
       changeFrequency: "monthly",
       priority: 1.0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site domain to qris.zeranel.dev. Changes include site identity metadata, canonical URLs for search engines, language-specific alternate routes, sitemap configuration, and search engine robots metadata. All configurations have been synchronized to the new domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->